### PR TITLE
Starting the server via "octoprint" is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN git clone --branch $tag https://github.com/foosel/OctoPrint.git /opt/octopri
 RUN useradd -ms /bin/bash octoprint && adduser octoprint dialout
 USER octoprint
 
-CMD ["/opt/octoprint/venv/bin/octoprint"]
+CMD ["/opt/octoprint/venv/bin/octoprint", "serve"]


### PR DESCRIPTION
There is a deprecation warning.
>Starting the server via "octoprint" is deprecated, please use "octoprint serve" from now on.
