### PR TITLE
Corrected VOLUME instruction && permissions fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ LABEL maintainer "gaetancollaud@gmail.com"
 ENV CURA_VERSION=15.04.6
 ARG tag=master
 
-VOLUME /user/octoprint/.octoprint
-
 WORKDIR /opt/octoprint
 
 # In case of alpine
@@ -37,11 +35,15 @@ RUN cd /tmp \
 RUN useradd -ms /bin/bash octoprint && adduser octoprint dialout
 RUN chown octoprint:octoprint /opt/octoprint
 USER octoprint
+#This fixes issues with the volume command setting wrong permissions
+RUN mkdir /home/octoprint/.octoprint
 
 #Install Octoprint
 RUN git clone --branch $tag https://github.com/foosel/OctoPrint.git /opt/octoprint \
   && virtualenv venv \
 	&& ./venv/bin/python setup.py install
+
+VOLUME /home/octoprint/.octoprint
 
 
 CMD ["/opt/octoprint/venv/bin/octoprint", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM python:2.7
 EXPOSE 5000
 LABEL maintainer "gaetancollaud@gmail.com"
+#Based on work done by gaetancollaud@gmail.com
+
 
 ENV CURA_VERSION=15.04.6
 ARG tag=master
@@ -35,7 +37,7 @@ RUN cd /tmp \
 
 #Create an octoprint user
 RUN useradd -ms /bin/bash octoprint && adduser octoprint dialout
-RUN chown octoprint:octoprint /opt/octoprint
+RUN chown octoprint:octoprint /opt/octoprint && chown octoprint:octoprint /user/octoprint
 USER octoprint
 
 #Install Octoprint

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 FROM python:2.7
 EXPOSE 5000
 LABEL maintainer "gaetancollaud@gmail.com"
-#Based on work done by gaetancollaud@gmail.com
-
 
 ENV CURA_VERSION=15.04.6
 ARG tag=master
@@ -37,7 +35,7 @@ RUN cd /tmp \
 
 #Create an octoprint user
 RUN useradd -ms /bin/bash octoprint && adduser octoprint dialout
-RUN chown octoprint:octoprint /opt/octoprint && chown octoprint:octoprint /user/octoprint
+RUN chown octoprint:octoprint /opt/octoprint
 USER octoprint
 
 #Install Octoprint


### PR DESCRIPTION
The active home directory for the user octoprint is /home/octoprint vs
/user/octoprint
When /home/octoprint/.octoprint is exposed as a volume, it has to be
the last thing exposed so that permissions can be set correctly and
data can be copied first.