### PR TITLE
update README docker run command to provide a volume list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can display the log using `docker-compose logs -f`
 
 ## Without docker-compose
 ```
-docker run -d -v ~/.octoprint:/home/octoprint/.octoprint --device /dev/ttyACM0:/dev/ttyACM0 -p 5000:5000 --name octoprint octoprint/octoprint
+docker run -d -v ./config:/home/octoprint/.octoprint --device /dev/ttyACM0:/dev/ttyACM0 -p 5000:5000 --name octoprint octoprint/octoprint
 ```
 
 # Additional tools

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can display the log using `docker-compose logs -f`
 
 ## Without docker-compose
 ```
-docker run -d -v --device /dev/ttyACM0:/dev/ttyACM0 -p 5000:5000 --name octoprint octoprint/octoprint
+docker run -d -v ~/.octoprint:/home/octoprint/.octoprint --device /dev/ttyACM0:/dev/ttyACM0 -p 5000:5000 --name octoprint octoprint/octoprint
 ```
 
 # Additional tools


### PR DESCRIPTION
The README lists a docker run command and provides a `-v` argument but no required list of volumes to mount. If copy/pasting this fails with a less than intuitive error. 
```
$ docker run -d -v --device /dev/ttyACM0:/dev/ttyACM0 -p 5000:5000 --name octoprint octoprint/octoprint
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
```

I just updated the docker run command in the README to use the volume mentioned in the docker-compose.yml