### PR TITLE
Fix FFMPEG #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install virtualenv
 
 #install ffmpeg
 RUN cd /tmp \
-  && wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
+  && wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armel-static.tar.xz \
 	&& mkdir -p /opt/ffmpeg \
 	&& tar xvf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1 \
   && rm -Rf /tmp/*


### PR DESCRIPTION
I had the following error when generating timelapse:
```bash
ERROR - Error while trying to run command /opt/ffmpeg/ffmpeg -framerate 25 -i "/home/octoprint/.octoprint/timelapse/tmp/Bath1_20200322223944-%d.jpg" -vcodec mpeg2video -threads 1 -r 25 -y -b 10000k -f vob -vf '[in] format=yuv420p [out]' "/home/octoprint/.octoprint/timelapse/.Bath1_20200322223944.mpg"
```

After going into the image to test the ffmpeg command I would get this error:
```bash
octoprint@d569dc39a31e:/opt/octoprint$ /opt/ffmpeg/ffmpeg 
bash: /opt/ffmpeg/ffmpeg: cannot execute binary file: Exec format error
```

This is related to issue #8.