### PR TITLE
Multi stage dynamically configurable build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config/generated
 config/logs
 config/timelapse
 config/uploads
+buildtest

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ services:
   - docker
 
 stages:
+  - validate
   - build
   - deploy
 
 jobs:
   include:
+    - stage: validate
+      script: make validate
     - stage: build
       script: make build
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
-sudo: required
-
 language: generic
 
+os: linux
 dist: bionic
 
-addons:
-  apt:
-    update: true
-    packages: 
-      - jq 
-      - make
+install: './.travis/install.sh'
 
 services:
   - docker
@@ -17,7 +11,6 @@ services:
 stages:
   - validate
   - build
-  - deploy
 
 jobs:
   include:
@@ -25,8 +18,9 @@ jobs:
       script: make validate
     - stage: build
       script: make build
-    - stage: deploy
-      script: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-      script: make release 
-      on:
-        branch: master
+
+deploy:
+  provider: script
+  script: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && make release
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: required
 
-env:
-  global:
-    - TAG=master DOCKER_TAG=automatic
-
 services:
   - docker
 arch:
@@ -11,8 +7,16 @@ arch:
   - arm64
 
 
-script:
-  - echo "Building octroprint branch/tag $TAG into octoprint/octoprint:$DOCKER_TAG"
-  - docker build --build-arg tag=$TAG -t octoprint/octoprint:$DOCKER_TAG .
-  - if [[ "$DOCKER_TAG" != "automatic" ]]; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
-  - if [[ "$DOCKER_TAG" != "automatic" ]]; then docker push octoprint/octoprint:$DOCKER_TAG; fi
+stages:
+	- build
+	- deploy
+
+jobs:
+  include:
+    - stage: build
+      script: make build
+    - stage: deploy
+      script: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+      script: make release 
+      on:
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ arch:
 
 
 stages:
-	- build
-	- deploy
+  - build
+  - deploy
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 sudo: required
 
+language: python
+
+dist: bionic
+
+addons:
+  apt:
+    update: true
+    packages: jq
+
 services:
   - docker
-arch:
-  - amd64
-  - arm64
-
 
 stages:
   - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 sudo: required
 
-language: python
+language: generic
 
 dist: bionic
 
 addons:
   apt:
     update: true
-    packages: jq
+    packages: 
+      - jq 
+      - make
 
 services:
   - docker

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -o errexit
+
+configure() {
+  update_docker_package
+  update_docker_configuration
+
+  echo "SUCCESS:
+  Done! Finished setting up Travis
+  "
+}
+
+update_docker_package() {
+  echo "INFO:
+  updating docker-ce
+  "
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  sudo apt-get update -y
+  sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  docker info
+}
+
+update_docker_configuration() {
+  echo "INFO:
+  Updating docker daemon config for buildkit
+  "
+
+  echo '{
+  "experimental": true,
+  "features": {
+    "buildkit": true}
+}' | sudo tee /etc/docker/daemon.json
+  sudo service docker restart
+}
+
+configure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,49 @@ A build environment that:
 - supports docker multi-stage builds
 - has `make` and `jq` commands available
 
+### Building
+
+ - [building images from latest stable release tag](#stable)
+ - [building images from master](#master)
+ - [alternate build configuration](#build-config)
+
+<a name="stable"></a>**Building stable release images**
+Running `make` will run a build that will result in 2 images based on the `Dockerfile`
+one using python 2.7, and one using the latest slim-buster python tag from docker hub.
+
+Resulting Tags/Images:
+
+```
+octoprint/octoprint:<version> (python 2.7)
+octoprint/octoprint:<version>-python3
+```
+
+<a name="master"></a>**Building 'latest' from master**
+
+Run `make build-master` or `make build-master-python3` to build the
+corresponding images:
+
+```
+octoprint/octoprint:latest
+octoprint/octoprint:python3
+```
+
+**Build Configurations**
+
+The `make` command will pull in the `config.env` file, and 
+utilize the variables within during the various stages of build,
+test, and release.
+
+To build alternate infrastructures, or get use different base images
+for end-use, you can either change the variables in `config.env`, or
+provide alternate saved configsets by using `cnf=<some_other_config.env`
+argument supplied to `make`. 
+
+For example, let's say you want to build using the full `buster` instead of the default `slim`, and publish to your own private repo. You could create a `private_buster_full.env` file, supplying the content below:
+
+```
+IMAGE=my.private.repo:5000/someuser/octoprint
+PYTHON_IMAGE_TAG=buster
+```
+
+Then run: `make cnf="private_buster_full.env" build-stable`, which would result in a python 3 based image with the tag `my.private.repo:5000/someuser/octoprint:<latest stable version>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Pre-requisites
+
+A build environment that:
+- supports docker multi-stage builds
+- has `make` and `jq` commands available
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,14 @@ ENV tag ${tag:-master}
 RUN apt update && apt install -y make g++ curl
 
 RUN	curl -fsSLO --compressed https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
-	&& mkdir -p /opt \
-  && tar xzf ${tag}.tar.gz --strip-components 1 -C /opt --no-same-owner
+	&& mkdir -p /opt/venv \
+  && tar xzf ${tag}.tar.gz --strip-components 1 -C /opt/venv --no-same-owner
 
 #install venv            
 RUN pip install virtualenv
 RUN python -m virtualenv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-WORKDIR /opt
+WORKDIR /opt/venv
 RUN python setup.py install
 
 
@@ -44,15 +44,15 @@ LABEL maintainer badsmoke "dockerhub@badcloud.eu"
 
 RUN groupadd --gid 1000 octoprint \
   && useradd --uid 1000 --gid octoprint --shell /bin/bash --create-home octoprint
-
+USER octoprint
 
 #Install Octoprint, ffmpeg, and cura engine
-COPY --from=compiler /opt/venv /opt/octoprint
+COPY --from=compiler /opt/venv /opt/venv
 COPY --from=ffmpeg /opt /opt/ffmpeg
 COPY --from=cura-compiler /opt /opt/cura
 
 # symlink packages to path
-RUN ln -s /opt/octoprint/bin/octoprint /usr/local/bin/octoprint
+ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 ARG PYTHON_IMAGE_TAG=2.7-slim-buster
 
+FROM buildpack-deps:curl AS ffmpeg
+RUN apt update && apt install -y xz-utils
+RUN curl -fsSLO https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
+  && mkdir -p /opt \
+  && tar -xJf ffmpeg-release-i686-static.tar.xz --strip-components=1 -C /opt
+
+
 FROM python:${PYTHON_IMAGE_TAG} AS cura-compiler
 
-RUN apt update && apt install g++ make
+ARG CURA_VERSION
+ENV CURA_VERSION ${CURA_VERSION:-15.04.6}
+
+RUN apt update && apt install -y g++ make curl
 RUN curl -fsSLO https://github.com/Ultimaker/CuraEngine/archive/${CURA_VERSION}.tar.gz \
   && mkdir -p /opt \
   && tar -xzf ${CURA_VERSION}.tar.gz --strip-components=1 -C /opt --no-same-owner
+WORKDIR /opt
 RUN make
 
 # build ocotprint
@@ -14,7 +25,7 @@ FROM python:${PYTHON_IMAGE_TAG} AS compiler
 ARG tag
 ENV tag ${tag:-master}
 
-RUN apt update && apt install make g++
+RUN apt update && apt install -y make g++ curl
 
 RUN	curl -fsSLO --compressed https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
 	&& mkdir -p /opt \
@@ -24,7 +35,7 @@ RUN	curl -fsSLO --compressed https://github.com/foosel/OctoPrint/archive/${tag}.
 RUN pip install virtualenv
 RUN python -m virtualenv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-COPY --from=deps /var/opt/octoprint .
+WORKDIR /opt
 RUN python setup.py install
 
 
@@ -34,20 +45,14 @@ LABEL maintainer badsmoke "dockerhub@badcloud.eu"
 RUN groupadd --gid 1000 octoprint \
   && useradd --uid 1000 --gid octoprint --shell /bin/bash --create-home octoprint
 
-# Install cura engine
-COPY --from=deps /opt/ffmpeg /opt/ffmpeg
 
-# Install ffmpeg
-RUN mkdir /opt/ffmpeg \
-	&& curl -L https://johnvansicle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
-	| tar zx --strip 1 -C /opt/ffmpeg
-
-#Install Octoprint
-RUN mkdir /opt/octoprint
-WORKDIR /opt/octoprint
+#Install Octoprint, ffmpeg, and cura engine
 COPY --from=compiler /opt/venv /opt/octoprint
-ENV PATH="/opt/octoprint:$PATH"
+COPY --from=ffmpeg /opt /opt/ffmpeg
+COPY --from=cura-compiler /opt /opt/cura
 
+# symlink packages to path
+#RUN ln -s /opt/cura /usr/local/bin/cura
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/
 USER octoprint
+VOLUME /home/octoprint
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["octoprint", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,30 +19,22 @@ RUN mkdir /opt/cura \
 
 
 # build cura engine
-FROM python:alpine AS cura-compiler
+FROM python:slim AS cura-compiler
 
-RUN apk add --no-cache linux-headers g++ make
 RUN mkdir -p /opt/cura/build
 WORKDIR /opt/cura
 COPY --from=deps /opt/cura .
 RUN make
 
 # build ocotprint
-FROM python:2.7-alpine AS compiler
-EXPOSE 5000
-LABEL maintainer badsmoke "dockerhub@badcloud.eu"
-
-ENV CURA_VERSION=15.04.6
-ARG tag=master
-
-WORKDIR /opt/octoprint
-
+FROM python:2.7-slim AS compiler
 
 #install venv            
 RUN pip install virtualenv
 
 
-FROM python:2.7-alpine
+FROM python:2.7-slim
+LABEL maintainer badsmoke "dockerhub@badcloud.eu"
 # Install cura engine and ffmpeg
 COPY --from=deps /opt/ffmpeg /opt/ffmpeg
 COPY --from=cura-compiler /opt/cura/build /opt/cura
@@ -50,4 +42,5 @@ COPY --from=cura-compiler /opt/cura/build /opt/cura
 #Install Octoprint
 
 
+EXPOSE 5000
 CMD ["/opt/octoprint/venv/bin/octoprint", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,12 +46,6 @@ RUN rm -rf /var/lib/apt/lists/*
 #install venv            
 RUN pip install virtualenv
 
-#install ffmpeg
-RUN cd /tmp \
-  && wget -O ffmpeg.tar.xz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
-	&& mkdir -p /opt/ffmpeg \
-	&& tar xvf ffmpeg.tar.xz -C /opt/ffmpeg --strip-components=1 \
-  && rm -Rf /tmp/*
 
 FROM python:3.8-slim-buster
 #Create an octoprint user
@@ -64,6 +58,8 @@ RUN mkdir /home/octoprint/.octoprint
 RUN git clone --branch $tag https://github.com/foosel/OctoPrint.git /opt/octoprint \
   && virtualenv venv \
 	&& ./venv/bin/python setup.py install
+
+COPY --from=deps /opt/ffmpeg /opt/ffmpeg
 VOLUME /home/octoprint/.octoprint
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ COPY --from=ffmpeg /opt /opt/ffmpeg
 COPY --from=cura-compiler /opt /opt/cura
 
 # symlink packages to path
-#RUN ln -s /opt/cura /usr/local/bin/cura
+RUN ln -s /opt/octoprint/bin/octoprint /usr/local/bin/octoprint
+
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,17 +44,17 @@ LABEL maintainer badsmoke "dockerhub@badcloud.eu"
 
 RUN groupadd --gid 1000 octoprint \
   && useradd --uid 1000 --gid octoprint --shell /bin/bash --create-home octoprint
-USER octoprint
 
 #Install Octoprint, ffmpeg, and cura engine
 COPY --from=compiler /opt/venv /opt/venv
 COPY --from=ffmpeg /opt /opt/ffmpeg
 COPY --from=cura-compiler /opt /opt/cura
 
-# symlink packages to path
+RUN chown -R octoprint:octoprint /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/
+USER octoprint
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["octoprint", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ ENV tag ${tag:-master}
 
 RUN apt-get update && apt-get install -y make g++ curl
 
-RUN	curl -fsSLO --compressed https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
+RUN	curl -fsSLO --compressed --retry 3 --retry-delay 10 \
+  https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
 	&& mkdir -p /opt/venv \
   && tar xzf ${tag}.tar.gz --strip-components 1 -C /opt/venv --no-same-owner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,24 @@
-FROM python:3.8-slim-buster
+FROM curlimages/curl AS deps 
+
+ARG CURA_VERSION
+ENV CURA_VERSION ${CURA_VERSION:-15.04.6}
+ARG tag
+ENV tag ${tag:-master}
+
+RUN mkdir -p /var/opt/octoprint \
+	&& curl -L https://github.com/foosel/OctoPrint/archive/${VERSION}.tar.gz \
+	| tar zx --strip 1 -C /var/opt/octoprint
+
+RUN mkdir /opt/ffmpeg \
+	&& curl -L https://johnvansicle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
+	| tar zx --strip 1 -C /opt/ffmpeg
+
+RUN mkdir /opt/cura \
+	&& curl -L https://github.com/Ultimaker/CuraEngine/archive/${CURA_VERSION}.tar.gz \
+	| tar zx --strip 1 -C /opt/cura
+
+
+FROM python:3.8 AS compiler
 EXPOSE 5000
 LABEL maintainer badsmoke "dockerhub@badcloud.eu"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_IMAGE_TAG=2.7-slim-buster
 
 FROM buildpack-deps:curl AS ffmpeg
-RUN apt update && apt install -y xz-utils
+RUN apt-get update && apt-get install -y xz-utils
 RUN curl -fsSLO https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz \
   && mkdir -p /opt \
   && tar -xJf ffmpeg-release-i686-static.tar.xz --strip-components=1 -C /opt
@@ -12,7 +12,7 @@ FROM python:${PYTHON_IMAGE_TAG} AS cura-compiler
 ARG CURA_VERSION
 ENV CURA_VERSION ${CURA_VERSION:-15.04.6}
 
-RUN apt update && apt install -y g++ make curl
+RUN apt-get update && apt-get install -y g++ make curl
 RUN curl -fsSLO https://github.com/Ultimaker/CuraEngine/archive/${CURA_VERSION}.tar.gz \
   && mkdir -p /opt \
   && tar -xzf ${CURA_VERSION}.tar.gz --strip-components=1 -C /opt --no-same-owner
@@ -25,7 +25,7 @@ FROM python:${PYTHON_IMAGE_TAG} AS compiler
 ARG tag
 ENV tag ${tag:-master}
 
-RUN apt update && apt install -y make g++ curl
+RUN apt-get update && apt-get install -y make g++ curl
 
 RUN	curl -fsSLO --compressed https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
 	&& mkdir -p /opt/venv \
@@ -40,7 +40,9 @@ RUN python setup.py install
 
 
 FROM python:${PYTHON_IMAGE_TAG} AS build
-LABEL maintainer badsmoke "dockerhub@badcloud.eu"
+LABEL description="The snappy web interface for your 3D printer"
+LABEL authors="longlivechief <chief@hackerhappyhour.com>, badsmoke <dockerhub@badcloud.eu>"
+LABEL issues="github.com/OcotPrint/docker/issues"
 
 RUN groupadd --gid 1000 octoprint \
   && useradd --uid 1000 --gid octoprint --shell /bin/bash --create-home octoprint

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /opt/octoprint
 
 
 #install necessary packages
-RUN apt update
 RUN apt install wget git xz-utils g++ make -y
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,19 @@ export $(shell sed 's/=.*//' $(cnf))
 # get the version of the latest stable release for build
 VERSION=$(shell ./version.sh | sed 's/"//g')
 
-.PHONY: build-master build-stable
+.DEFAULT_GOAL := build
+
+build: build-stable build-stable-python3
 
 build-master:
 	docker build -t $(IMAGE) .
 
+build-master-python3:
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
+
 build-stable:
 	docker build --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+
+build-stable-python3:
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):${VERSION}-python3 .
 

--- a/Makefile
+++ b/Makefile
@@ -12,25 +12,25 @@ build: build-stable build-stable-python3 build-master build-master-python3
 
 build-master:
 	@echo 'building $(IMAGE) from master with python 2.7'
-	docker build -t $(IMAGE) .
+	@docker build -t $(IMAGE) .
 
 build-master-python3:
 	@echo 'building $(IMAGE):python3 from master with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
+	@docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
 
 build-stable:
 	@echo 'building stable, version: ${VERSION} with python 2'
-	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+	@docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
 
 build-stable-python3:
 	@echo 'building stable, version: ${VERSION} with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION)-python3 .
+	@docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION)-python3 .
 
 release:
-	docker push $(IMAGE):latest
-	docker push $(IMAGE):${VERSION}
-	docker push $(IMAGE):python3
-	docker push $(IMAGE):${VERSION}-python3
+	@docker push $(IMAGE):latest
+	@docker push $(IMAGE):${VERSION}
+	@docker push $(IMAGE):python3
+	@docker push $(IMAGE):${VERSION}-python3
 
 validate:
 	@echo latest stable tag: ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,19 @@ build: build-stable build-stable-python3 build-master build-master-python3
 
 build-master:
 	@echo 'building $(IMAGE) from master with python 2.7'
-	@docker build -t $(IMAGE) .
+	@docker build --progress plain -t $(IMAGE) .
 
 build-master-python3:
 	@echo 'building $(IMAGE):python3 from master with python 3'
-	@docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
+	@docker build --progress plain --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
 
 build-stable:
 	@echo 'building stable, version: ${VERSION} with python 2'
-	@docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+	@docker build --progress plain --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
 
 build-stable-python3:
 	@echo 'building stable, version: ${VERSION} with python 3'
-	@docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION)-python3 .
+	@docker build --progress plain --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION)-python3 .
 
 release:
 	@docker push $(IMAGE):latest

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,11 @@ VERSION := $(shell ./version.sh)
 build: build-stable build-stable-python3
 
 build-master:
+	@echo 'building $(IMAGE) from master with python 2.7'
 	docker build -t $(IMAGE) .
 
 build-master-python3:
+	@echo 'building $(IMAGE) from master with python 3'
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
 
 build-stable:
@@ -32,4 +34,4 @@ release:
 	docker push $(IMAGE):$(VERSION)-python3
 
 validate:
-	@echo $(VERSION)
+	@echo latest stable release: $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,18 @@ build-master-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
 
 build-stable:
-	@echo 'building stable, version: $(VERSION) with python 2'
-	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION) .
+	@echo 'building stable, version: ${VERSION} with python 2'
+	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
 
 build-stable-python3:
-	@echo 'building stable, version: $(VERSION) with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .
+	@echo 'building stable, version: ${VERSION} with python 3'
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION)-python3 .
 
 release:
 	docker push $(IMAGE):latest
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):${VERSION}
 	docker push $(IMAGE):python3
-	docker push $(IMAGE):$(VERSION)-python3
+	docker push $(IMAGE):${VERSION}-python3
 
 validate:
-	@echo latest stable tag: $(VERSION)
+	@echo latest stable tag: ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
-.PHONY: build-alpine
+.PHONY: build-alpine deps
 build-alpine:
 	docker build -t octoprint -f Dockerfile .
+deps:
+	docker build -t octoprint:deps --target deps -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build-alpine
+build-alpine:
+	docker build -t octoprint -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(cnf)
 export $(shell sed 's/=.*//' $(cnf))
 
 # get the version of the latest stable release for build
-VERSION=$(shell ./version.sh | sed 's/"//g')
+VERSION := $(shell ./version.sh)
 
 .DEFAULT_GOAL := build
 
@@ -18,7 +18,7 @@ build-master-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
 
 build-stable:
-	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION) .
+	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION) .
 
 build-stable-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
-.PHONY: build-master
+#import config.
+# You can change the default config with `make cnf="config_special.env" build`
+cnf ?= config.env
+include $(cnf)
+export $(shell sed 's/=.*//' $(cnf))
+
+# get the version of the latest stable release for build
+VERSION=$(shell ./version.sh | sed 's/"//g')
+
+.PHONY: build-master build-stable
+
 build-master:
-	docker build -t octoprint -f Dockerfile .
+	docker build -t $(IMAGE) .
+
+build-stable:
+	docker build --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ build-master-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
 
 build-stable:
-	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):$(VERSION) .
+	@echo 'building stable, version: $(VERSION) with python 2'
+	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION) .
 
 build-stable-python3:
+	@echo 'building stable, version: $(VERSION) with python 3'
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .
 
 release:

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ build-stable:
 
 build-stable-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):${VERSION}-python3 .
+
+release:
+	docker push $(IMAGE):latest
+	docker push $(IMAGE):${VERSION}
+	docker push $(IMAGE):python3
+	docker push $(IMAGE):${VERSION}-python3

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ build-master:
 	docker build -t $(IMAGE) .
 
 build-master-python3:
-	@echo 'building $(IMAGE) from master with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
+	@echo 'building $(IMAGE):python3 from master with python 3'
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3 .
 
 build-stable:
 	@echo 'building stable, version: $(VERSION) with python 2'
@@ -24,7 +24,7 @@ build-stable:
 
 build-stable-python3:
 	@echo 'building stable, version: $(VERSION) with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(get_version)-python3 .
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .
 
 release:
 	docker push $(IMAGE):latest

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,10 @@ include $(cnf)
 export $(shell sed 's/=.*//' $(cnf))
 
 # get the version of the latest stable release for build
-VERSION := $(shell ./version.sh)
-
+VERSION:= $(shell ./version.sh)
 .DEFAULT_GOAL := build
 
-build: build-stable build-stable-python3
+build: build-stable build-stable-python3 build-master build-master-python3
 
 build-master:
 	@echo 'building $(IMAGE) from master with python 2.7'
@@ -25,7 +24,7 @@ build-stable:
 
 build-stable-python3:
 	@echo 'building stable, version: $(VERSION) with python 3'
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(get_version)-python3 .
 
 release:
 	docker push $(IMAGE):latest
@@ -34,4 +33,4 @@ release:
 	docker push $(IMAGE):$(VERSION)-python3
 
 validate:
-	@echo latest stable release: $(VERSION)
+	@echo latest stable tag: $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: build-alpine deps
-build-alpine:
+.PHONY: build-master
+build-master:
 	docker build -t octoprint -f Dockerfile .
-deps:
-	docker build -t octoprint:deps --target deps -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ build-master-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
 
 build-stable:
-	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION) .
 
 build-stable-python3:
-	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):${VERSION}-python3 .
+	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=$(VERSION) -t $(IMAGE):$(VERSION)-python3 .
 
 release:
 	docker push $(IMAGE):latest
-	docker push $(IMAGE):${VERSION}
+	docker push $(IMAGE):$(VERSION)
 	docker push $(IMAGE):python3
-	docker push $(IMAGE):${VERSION}-python3
+	docker push $(IMAGE):$(VERSION)-python3

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ build-master-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster -t $(IMAGE):python3
 
 build-stable:
-	docker build --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
+	docker build --build-arg PYTHON_IMAGE_TAG=$(PYTHON_IMAGE_TAG) --build-arg tag=${VERSION} -t $(IMAGE):${VERSION} .
 
 build-stable-python3:
 	docker build --build-arg PYTHON_IMAGE_TAG=slim-buster --build-arg tag=${VERSION} -t $(IMAGE):${VERSION}-python3 .
-

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ release:
 	docker push $(IMAGE):$(VERSION)
 	docker push $(IMAGE):python3
 	docker push $(IMAGE):$(VERSION)-python3
+
+validate:
+	@echo $(VERSION)

--- a/config.env
+++ b/config.env
@@ -1,2 +1,3 @@
  # Configs for build and test
  IMAGE=octoprint/octoprint
+ PYTHON_IMAGE_TAG=2.7-slim-buster

--- a/config.env
+++ b/config.env
@@ -1,0 +1,2 @@
+ # Configs for build and test
+ IMAGE=octoprint/octoprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: '3.7'
+
 services:
   octoprint:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.7'
 
 services:
   octoprint:
-    build: .
-    image: badsmoke/octoprint
-    container_name: octoprint
+    image: octoprint/octoprint
     ports:
       - 5000:5000
     # devices:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- octoprint "$@"
+fi
+
+exec "$@"

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -x
+## get latest stable tag
+curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
+	jq .tag_name

--- a/version.sh
+++ b/version.sh
@@ -1,3 +1,4 @@
 ## get latest stable tag from github foosel/OctoPrint
 exec curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
 	jq '.tag_name' | sed 's/"//g'
+

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-set -x
 ## get latest stable tag from github foosel/OctoPrint
-curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
-	jq .tag_name
+exec curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
+	jq '.tag_name' | sed 's/"//g'

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -x
-## get latest stable tag
+## get latest stable tag from github foosel/OctoPrint
 curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
 	jq .tag_name

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,2 @@
 ## get latest stable tag from github foosel/OctoPrint
-exec curl -s https://api.github.com/repos/foosel/OctoPrint/releases/latest |
-	jq '.tag_name' | sed 's/"//g'
-
+curl --head --silent --write-out %{redirect_url} --output /dev/null https://github.com/foosel/OctoPrint/releases/latest | awk -F '/' '{print $8}'


### PR DESCRIPTION
There are a lot of changes here. I tried to make the history of each commit a step by step of what is changing and why, so I'll just summarize the changes in full here.  I have also added documentation about configuring the build in a new `CONTRIBUTING.md` file, so be sure to read that as part of the PR.

I tried to break this up into smaller chunks, but there wasn't really a way to do this without going all in, and this was the first true stopping point. 

PR's to follow this will do change the final base image to create a much _much_ smaller final image, and will also create multi-arch builds by default, including appropriate versions of ffmpeg (see #18 ).

### Changes

- used multi staged builds for faster build and smaller final images (eliminates the need to do things like clean sources and tmp dirs files used for unpacking
- updated LABELS in final image (existing [maintainer LABEL was deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)
- added Makefile which has dynamic configuration supplied, and builds 4 different images
  - build from master using python 2.7
  - build from master using python 3
  - build from latest stable tag using python 2.7
  - build from latest stable tag using python 3
- The latest stable tag is dynamically pulled from the github releases api from foosel/OctoPrint, so that we can automatically trigger this build from that repo without having to update any configs, and automatically will get appropriate tags (/cc @foosel )
- The image now has an entrypoint that will allow users to supply a alternative default command (useful for debugging)
- created uid and gid for octoprint user that will allow a user to use the `--user` flag in a seamless fashion. If they don't supply a user, the user `octoprint` will be assigned the uid/gid and be used in the resulting container.
- updated the example `docker-compose.yml` to use `version: '3.7'` so that we can make future changes with networks and volumes if need be and not worry about technical debt
- set up the build in such a way that multi-arch builds will be simple to add as a next step
- created a dynamic config (see CONTRIBUTING) for `make` that will support image tagging in any forked/upstream CI/CD with a drop in config 

### Travis Changes
- created 2 stages `build` and `release`
- added a `make release` that will publish all 4 images at once by default
- made the publish of tags to the dockerhub repo conditional to only run on the master branch builds