### PR TITLE
add support and builds for armhf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
   amd64) ARCH='amd64';; \
   arm64) ARCH='arm64';; \
+  armhf) ARCH='armhf';; \
   *) echo "unsupported architecture: $(dpkg --print-architecture)"; exit 1 ;; \
   esac \
   && set -ex \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 
 buildx:
 	@echo '[buildx]: building image: ${IMG} for all architectures'
-	@docker buildx build --platform linux/amd64,linux/arm64 \
+	@docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
@@ -38,7 +38,7 @@ manifest:
 
 buildx-push:
 	@echo '[buildx]: building and pushing images: ${IMG} for all supported architectures'
-	docker buildx build --push --platform linux/arm64,linux/amd64 \
+	docker buildx build --push --platform linux/arm64,linux/amd64,linux/arm/v7 \
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \


### PR DESCRIPTION
Limited to the architecture platform the python base image supports, so only able to add armv7 at this time.

closes #6