### PR TITLE
Update octoprint src path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV tag ${tag:-master}
 RUN apt-get update && apt-get install -y build-essential curl
 
 RUN	curl -fsSLO --compressed --retry 3 --retry-delay 10 \
-  https://github.com/foosel/OctoPrint/archive/${tag}.tar.gz \
+  https://github.com/OctoPrint/OctoPrint/archive/${tag}.tar.gz \
 	&& mkdir -p /opt/venv \
   && tar xzf ${tag}.tar.gz --strip-components 1 -C /opt/venv --no-same-owner
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # You can change the default config with `make cnf="config_special.env" build`
 cnf ?= env.mk
 include $(cnf)
-IMG = "$(REGISTRY)/$(IMAGE):$(TAG)"
 CACHE = $(REGISTRY)/$(IMAGE):cache
+IMG = "$(REGISTRY)/$(IMAGE):$(TAG)" 
 
-OCTOPRINT_VERSION:= $(shell ./scripts/version.sh "foosel/OctoPrint")
+OCTOPRINT_VERSION:= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
 
 .DEFAULT_GOAL := build
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 cnf ?= env.mk
 include $(cnf)
 CACHE = $(REGISTRY)/$(IMAGE):cache
-IMG = "$(REGISTRY)/$(IMAGE):$(TAG)" 
+IMG = "$(REGISTRY)/$(IMAGE)" 
+IMG_TAG?=latest
 
-OCTOPRINT_VERSION:= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
+OCTOPRINT_VERSION?= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
 
 .DEFAULT_GOAL := build
 
@@ -31,10 +32,8 @@ buildx:
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
-		--progress plain -t ${IMG} .
-
-manifest:
-	docker manifest inspect ${IMG}
+		--build-arg tag=${OCTOPRINT_VERSION} \
+		--progress plain -t ${IMG}:${IMG_TAG} .
 
 buildx-push:
 	@echo '[buildx]: building and pushing images: ${IMG} for all supported architectures'
@@ -42,4 +41,5 @@ buildx-push:
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
 		--build-arg PYTHON_BASE_IMAGE=$(PYTHON_BASE_IMAGE) \
-		--progress plain -t ${IMG} .
+		--build-arg tag=${OCTOPRINT_VERSION} \
+		--progress plain -t ${IMG}:${IMG_TAG} .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 cnf ?= env.mk
 include $(cnf)
 CACHE = $(REGISTRY)/$(IMAGE):cache
-IMG = "$(REGISTRY)/$(IMAGE)" 
+IMG = $(REGISTRY)/$(IMAGE)
 IMG_TAG?=latest
 
 OCTOPRINT_VERSION?= $(shell ./scripts/version.sh "OctoPrint/OctoPrint")
@@ -27,7 +27,7 @@ build:
 
 
 buildx:
-	@echo '[buildx]: building image: ${IMG} for all architectures'
+	@echo '[buildx]: building image: ${IMG}:${IMG_TAG} for all architectures'
 	@docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 \
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \
@@ -36,7 +36,7 @@ buildx:
 		--progress plain -t ${IMG}:${IMG_TAG} .
 
 buildx-push:
-	@echo '[buildx]: building and pushing images: ${IMG} for all supported architectures'
+	@echo '[buildx]: building and pushing images: ${IMG}:${IMG_TAG} for all supported architectures'
 	docker buildx build --push --platform linux/arm64,linux/amd64,linux/arm/v7 \
 		--cache-from ${CACHE} \
 		--cache-to	${CACHE} \

--- a/env.mk
+++ b/env.mk
@@ -2,7 +2,6 @@
 REGISTRY?=docker.io
 DOCKER_USERNAME?=octoprint
 IMAGE?=octoprint/octoprint
-TAG?=latest
 PLATFORM?=arm64
 DOCKERFILE_LOCATION?="./Dockerfile"
 PYTHON_BASE_IMAGE?=2.7-slim-buster


### PR DESCRIPTION
- updates to use `OctoPrint/OctoPrint` instead of `foosel/OctoPrint`
- add version tagging to Makefile
 - will assign `latest` tag if no IMG_TAG is used or in env
 - will pass the latest stable release tag to docker unless overridden by command/env