### PR TITLE
Update Dockerfile VOLUME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,6 @@ ENV PATH="/opt/venv/bin:/opt/ffmpeg:/opt/cura:$PATH"
 EXPOSE 5000
 COPY docker-entrypoint.sh /usr/local/bin/
 USER octoprint
-VOLUME /home/octoprint
+VOLUME /home/octoprint/.octoprint
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["octoprint", "serve"]


### PR DESCRIPTION
README states ` -v ./config:/home/octoprint/.octoprint` as a required mount but the Dockerfile lists `VOLUME /home/octoprint` instead. Mounting  /home/octoprint as per the Dockerfile seems to cause execution permission errors on my system. Changing to `VOLUME /home/octoprint/.octoprint` in the Dockerfile fixes these issues.

