### PR TITLE
Fix buildx fail

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -18,7 +18,8 @@ jobs:
         id: setup
         uses: crazy-max/ghaction-docker-buildx@v1
         with:
-          version: v0.3.1
+          buildx-version: latest
+          qemu-version: latest
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Run Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pip install virtualenv
 RUN python -m virtualenv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /opt/venv
-RUN python setup.py install
+RUN pip install .
 
 
 FROM python:${PYTHON_BASE_IMAGE} AS build


### PR DESCRIPTION
Switched `compiler` stage to use `pip install .` instead of `python setup.py install`.  This matches the octoprint/octoprint ci build flow, and should produce consistent build success/fails as upstream, and not cause PR's to fail even when they are building stable octoprint tags.

Fixes #39 