### PR TITLE
Enable compression in HAProxy

### DIFF
--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -22,7 +22,6 @@ defaults
 frontend public
 	bind *:80 alpn h2,http/1.1
 	filter compression
-	http-request set-header Accept-Encoding "gzip, deflate"
 	compression algo gzip
 	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml 
 	compression offload
@@ -32,7 +31,6 @@ frontend public
 backend octoprint
 	http-request replace-path /(.*)     /\1
 	filter compression
-	http-request set-header Accept-Encoding "gzip, deflate"
 	compression algo gzip
 	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
 	compression offload
@@ -42,7 +40,6 @@ backend octoprint
 backend webcam
 	http-request replace-path /webcam/(.*)     /\1
 	filter compression
-	http-request set-header Accept-Encoding "gzip, deflate"
 	compression algo gzip
 	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
 	compression offload

--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -21,14 +21,29 @@ defaults
 
 frontend public
         bind *:80 alpn h2,http/1.1
+        filter compression
+        http-request set-header Accept-Encoding "gzip, deflate"
+        compression algo gzip
+        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml 
+        compression offload
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
 
 backend octoprint
         http-request replace-path /(.*)     /\1
+        filter compression
+        http-request set-header Accept-Encoding "gzip, deflate"
+        compression algo gzip
+        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
+        compression offload
         option forwardfor
         server octoprint1 127.0.0.1:5000
 
 backend webcam
         http-request replace-path /webcam/(.*)     /\1
+        filter compression
+        http-request set-header Accept-Encoding "gzip, deflate"
+        compression algo gzip
+        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
+        compression offload
         server webcam1  127.0.0.1:8080

--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -1,49 +1,49 @@
 global
-        maxconn 4096
-        user haproxy
-        group haproxy
-        daemon
-        log 127.0.0.1 local0 debug
+	maxconn 4096
+	user haproxy
+	group haproxy
+	daemon
+	log 127.0.0.1 local0 debug
 
 defaults
-        log     global
-        mode    http
-        option  httplog
-        option  dontlognull
-        retries 3
-        option redispatch
-        option http-server-close
-        option forwardfor
-        maxconn 2000
-        timeout connect 5s
-        timeout client  15m
-        timeout server  15m
+	log     global
+	mode    http
+	option  httplog
+	option  dontlognull
+	retries 3
+	option redispatch
+	option http-server-close
+	option forwardfor
+	maxconn 2000
+	timeout connect 5s
+	timeout client  15m
+	timeout server  15m
 
 frontend public
-        bind *:80 alpn h2,http/1.1
-        filter compression
-        http-request set-header Accept-Encoding "gzip, deflate"
-        compression algo gzip
-        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml 
-        compression offload
-        use_backend webcam if { path_beg /webcam/ }
-        default_backend octoprint
+	bind *:80 alpn h2,http/1.1
+	filter compression
+	http-request set-header Accept-Encoding "gzip, deflate"
+	compression algo gzip
+	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml 
+	compression offload
+	use_backend webcam if { path_beg /webcam/ }
+	default_backend octoprint
 
 backend octoprint
-        http-request replace-path /(.*)     /\1
-        filter compression
-        http-request set-header Accept-Encoding "gzip, deflate"
-        compression algo gzip
-        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
-        compression offload
-        option forwardfor
-        server octoprint1 127.0.0.1:5000
+	http-request replace-path /(.*)     /\1
+	filter compression
+	http-request set-header Accept-Encoding "gzip, deflate"
+	compression algo gzip
+	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
+	compression offload
+	option forwardfor
+	server octoprint1 127.0.0.1:5000
 
 backend webcam
-        http-request replace-path /webcam/(.*)     /\1
-        filter compression
-        http-request set-header Accept-Encoding "gzip, deflate"
-        compression algo gzip
-        compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
-        compression offload
-        server webcam1  127.0.0.1:8080
+	http-request replace-path /webcam/(.*)     /\1
+	filter compression
+	http-request set-header Accept-Encoding "gzip, deflate"
+	compression algo gzip
+	compression type application/atom+xml application/geo+json application/javascript application/x-javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.api+json application/xml+rss application/xhtml+xml application/xml image/png font/eot font/otf font/ttf image/svg+xml text/css text/javascript text/plain text/xml
+	compression offload
+	server webcam1  127.0.0.1:8080


### PR DESCRIPTION
This will enable compression for the HTTP data transfer, significantly decreasing loading times/network traffic.

The `compression offload` configuration offloads the compression to HAProxy itself instead of OctoPrint which is also a good bit faster.